### PR TITLE
Replace links to wildme-docs/master with wildme-docs/main

### DIFF
--- a/docs/how_to_edit.md
+++ b/docs/how_to_edit.md
@@ -21,7 +21,7 @@ Every page (including this one) has an button at the bottom labeled "Edit this p
 
 ## Creating a new page 
 
-To create a new page, start at the [docs root](https://github.com/WildMeOrg/docusaurus-test/tree/master/docs) navigate to the appropriate folder on Github and click "Add file" in the upper right hand corner. Name your file using the format `your_article_title.md`. Copy the following template into the new page:
+To create a new page, start at the [docs root](https://github.com/WildMeOrg/wildme-docs/tree/main/docs) navigate to the appropriate folder on Github and click "Add file" in the upper right hand corner. Name your file using the format `your_article_title.md`. Copy the following template into the new page:
 
 ```
 ---
@@ -44,7 +44,7 @@ Now it's just a matter of replacing the content above with the actual page conte
 
 ## Adding pages to the side navigation
 
-First, you have to determine your page reference. The *page reference* is a combination of the path to the page from the [docs](https://github.com/WildMeOrg/wildme-docs/tree/master/docs) folder and the ID of the page. These two bits of information are combined with a forward slash `/`.
+First, you have to determine your page reference. The *page reference* is a combination of the path to the page from the [docs](https://github.com/WildMeOrg/wildme-docs/tree/main/docs) folder and the ID of the page. These two bits of information are combined with a forward slash `/`.
 
 For example, if your page is located at `/docs/researchers/features/newpage.md` and newpage.md contains
 
@@ -57,13 +57,13 @@ title: Manual Annotation
 This article is about a new feature called...
 ```
 
-then your reference would be `researchers/features/manual_annotation`. Now all you need to do is edit the [sidebar definition file](https://github.com/WildMeOrg/wildme-docs/edit/master/sidebars.js) to include your new menu item. After you add the page reference in the appropriate location, scroll to the bottom of the page and write a brief description of your change. Click "propose changes" and they will be sent to Wild Me staff for review.
+then your reference would be `researchers/features/manual_annotation`. Now all you need to do is edit the [sidebar definition file](https://github.com/WildMeOrg/wildme-docs/edit/main/sidebars.js) to include your new menu item. After you add the page reference in the appropriate location, scroll to the bottom of the page and write a brief description of your change. Click "propose changes" and they will be sent to Wild Me staff for review.
 
 ## Adding images
 
 Images must be added to the docs _before_ they can be used in a page. First, rename your image files using the following format: `page_name_imagenumber.format`. For example, the third image on the "Researcher overview page" should be named `researcher_overview_3.jpg`.
 
-Go to the [img folder](https://github.com/WildMeOrg/docusaurus-test/tree/master/static/img) and click "add file" in the upper right hand corner.  Click "upload files", drag the images in, and wait for the upload to finish.  When the uploads finish, scroll to the bottom of the page and write a brief description of the images you added. Click "propose changes" and they will be sent to Wild Me staff for review.
+Go to the [img folder](https://github.com/WildMeOrg/wildme-docs/tree/main/static/img) and click "add file" in the upper right hand corner.  Click "upload files", drag the images in, and wait for the upload to finish.  When the uploads finish, scroll to the bottom of the page and write a brief description of the images you added. Click "propose changes" and they will be sent to Wild Me staff for review.
 
 To use an image in a page, use the following format:
 

--- a/docs/technical_how_to_edit.md
+++ b/docs/technical_how_to_edit.md
@@ -21,7 +21,7 @@ The fastest and easiest way to contribute is to clone the repository and run the
 
 ## Editing documentation 
 
-The documentation is located in the `docs` folder. Each markdown file is used to generate a single page of documentation. To set this up properly, each markdown file has a header that starts and ends with `---`. There are a number of options you can specify, but the required options are `id` and `title`. Take a look at the [markdown file](https://github.com/WildMeOrg/wildme-docs/blob/master/docs/technical_how_to_edit.md) that generates this page for an example. 
+The documentation is located in the `docs` folder. Each markdown file is used to generate a single page of documentation. To set this up properly, each markdown file has a header that starts and ends with `---`. There are a number of options you can specify, but the required options are `id` and `title`. Take a look at the [markdown file](https://github.com/WildMeOrg/wildme-docs/blob/main/docs/technical_how_to_edit.md) that generates this page for an example. 
 
 When you create a new page, you can add it to the navigation component by registering it in `sidebars.js`. In this file each page is referred to by its path relative to the `docs` folder plus the page ID. For example if you create a page with ID `new_features` in `/docs/researchers/news/newFeatures.md`, you could refer to that page as `researchers/news/new_features`. 
 

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -108,13 +108,13 @@ module.exports = {
         docs: {
           sidebarPath: require.resolve("./sidebars.js"),
           // Please change this to your repo.
-          editUrl: "https://github.com/WildMeOrg/wildme-docs/edit/master/",
+          editUrl: "https://github.com/WildMeOrg/wildme-docs/edit/main/",
         },
         blog: {
           showReadingTime: true,
           // Please change this to your repo.
           editUrl:
-            "https://github.com/WildMeOrg/wildme-docs/edit/master/website/blog/",
+            "https://github.com/WildMeOrg/wildme-docs/edit/main/website/blog/",
         },
         theme: {
           customCss: require.resolve("./src/css/custom.css"),


### PR DESCRIPTION
- Replaces links to this site's master branch with the main branch.
  -  file editing was not working for several files that exist in `main` but not `master`
- Updates some links from `docusaurus-test` to `wildme-docs`