### PR TITLE
Restore elasticsearch in sidebar

### DIFF
--- a/sidebars.js
+++ b/sidebars.js
@@ -143,6 +143,7 @@ module.exports = {
     Codex: [
       "developers/codex_overview",
       "developers/houston",
+      "developers/elasticsearch",
       "developers/codex_frontend",
       "developers/debugging",
       {


### PR DESCRIPTION
Elasticsearch was accidentally removed from the developer sidebar when resolving merge conflicts in #64. I've double checked the developer sidebar and I don't think that anything else was lost in the merge.

Elasticsearch was originally added in https://github.com/WildMeOrg/wildme-docs/commit/fc46b0b87b4f3a327dad530e4b0d41cfdfd92c2d.